### PR TITLE
Make File::getFilename() public and return correct value in File::doFlush().

### DIFF
--- a/src/Backend/File.php
+++ b/src/Backend/File.php
@@ -84,14 +84,14 @@ class File extends PhpFileCache implements Backend
     {
         // if the directory does not exist, do not bother to continue clearing
         if (!is_dir($this->directory)) {
-            return;
+            return false;
         }
 
         foreach ($this->getFileIterator() as $name => $file) {
             $this->opCacheInvalidate($name);
         }
 
-        parent::doFlush();
+        return parent::doFlush();
     }
 
     private function invalidateCacheFile($id)
@@ -105,7 +105,7 @@ class File extends PhpFileCache implements Backend
      *
      * @return string
      */
-    protected function getFilename($id)
+    public function getFilename($id)
     {
         $path = $this->directory . DIRECTORY_SEPARATOR;
         $id   = preg_replace('@[\\\/:"*?<>|]+@', '', $id);

--- a/tests/Backend/FileTest.php
+++ b/tests/Backend/FileTest.php
@@ -85,4 +85,23 @@ class FileTest extends \PHPUnit_Framework_TestCase
         $this->assertLessThan(time() + 550, $contents['lifetime']);
     }
 
+    /**
+     * @dataProvider getTestDataForGetFilename
+     */
+    public function test_getFilename_shouldConstructFilenameFromId($id, $expectedFilename)
+    {
+        $this->assertEquals($expectedFilename, $this->cache->getFilename($id));
+    }
+
+    public function getTestDataForGetFilename()
+    {
+        $dir = realpath($this->getPath());
+
+        return [
+            ['genericid', $dir . '/genericid.php'],
+            ['id with space', $dir . '/id with space.php'],
+            ['id \/ with :"?_ spe<>cial cha|rs', $dir . '/id  with _ special chars.php'],
+            ['with % allowed & special chars', $dir . '/with % allowed & special chars.php'],
+        ];
+    }
 }


### PR DESCRIPTION
* `File::getFilename()` needs to be public for a plugin that needs to use the path after a specific entry is deleted.
* `doFlush()` needs to return the success value so the plugin can tell if a flush succeeded.

There will be new events in core, but I haven't put that PR up.

CC @tsteur