### PR TITLE
Improve fetching cache from chained backend

### DIFF
--- a/src/Backend/Chained.php
+++ b/src/Backend/Chained.php
@@ -38,9 +38,8 @@ class Chained implements Backend
     public function doFetch($id)
     {
         foreach ($this->backends as $key => $backend) {
-            if ($backend->doContains($id)) {
-                $value = $backend->doFetch($id);
-
+            $value = $backend->doFetch($id);
+            if ($value !== false) {
                 // EG If chain is ARRAY => REDIS => DB and we find result in DB we will update REDIS and ARRAY
                 for ($subKey = $key - 1 ; $subKey >= 0 ; $subKey--) {
                     $this->backends[$subKey]->doSave($id, $value, 300); // TODO we should use the actual TTL here


### PR DESCRIPTION
refs #19

While profiling a production server noticed during a tracking request which takes like 50ms we spent 2.73 ms in `doContains` and 2ms in `doFetch`. Considering this is like 4% of the time spent of a tracking request in `doContains()` even though it's not needed. The other backends will silently fail anyway and return false when a cache is not contained in a backend. And sometimes they do the `doContains` in `doFetch` anyway (eg ArrayCache).

FYI @mattab