### PR TITLE
Catch a parse error in case cache file does not get written correctly

### DIFF
--- a/tests/Backend/FileTest.php
+++ b/tests/Backend/FileTest.php
@@ -85,6 +85,15 @@ class FileTest extends \PHPUnit_Framework_TestCase
         $this->assertLessThan(time() + 550, $contents['lifetime']);
     }
 
+    public function test_doFetch_ParseError()
+    {
+        $test = $this->cache->getFilename('foo');
+        file_put_contents($test, '<?php echo $dat
+    && foo();flelr');
+
+        $this->assertFalse($this->cache->doFetch('foo'));
+    }
+
     /**
      * @dataProvider getTestDataForGetFilename
      */


### PR DESCRIPTION
Avoids getting a message like this in the UI:

`syntax error, unexpected '=>' (T_DOUBLE_ARROW), expecting ')'`

Instead we return false so the cache gets written again. Not sure if otherwise it would even leak potential data as it shows part of the broken part of the cache. Also it makes the app more stable.