### PR TITLE
Fix redis should use del instead of deprecated method delete

### DIFF
--- a/src/Backend/Redis.php
+++ b/src/Backend/Redis.php
@@ -28,9 +28,9 @@ class Redis extends RedisCache implements Backend
         return parent::doSave($id, $data, $lifeTime);
     }
 
-    public function doDelete($id)
+    protected function doDelete($id)
     {
-        return parent::doDelete($id);
+        return $this->getRedis()->del($id) >= 0;
     }
 
     public function doFlush()

--- a/src/Backend/Redis.php
+++ b/src/Backend/Redis.php
@@ -28,7 +28,7 @@ class Redis extends RedisCache implements Backend
         return parent::doSave($id, $data, $lifeTime);
     }
 
-    protected function doDelete($id)
+    public function doDelete($id)
     {
         return $this->getRedis()->del($id) >= 0;
     }


### PR DESCRIPTION
fix #23
fix https://github.com/matomo-org/matomo/issues/15532

couldn't upgrade the doctrine dependency since it requires PHP 7.1.

Fixed this instead in here directly which should be fine as it's likely the last change for 1.X anyway