### PR TITLE
Fix PHP 8.1 Deprecation

### DIFF
--- a/src/Backend/Factory.php
+++ b/src/Backend/Factory.php
@@ -59,7 +59,7 @@ class Factory
         if (empty($options['unix_socket'])) {
             $redis->connect($options['host'], $options['port'], $timeout);
         } else {
-            $redis->connect($options['unix_socket'], null, $timeout);
+            $redis->connect($options['unix_socket'], 0, $timeout);
         }
 
         if (!empty($options['password'])) {


### PR DESCRIPTION
PHP 8.1 throws the error "PHP Deprecated: Redis::connect(): Passing null to parameter #2 ($port) of type int is deprecated in /var/www/matomo/vendor/matomo/cache/src/Backend/Factory.php on line 62" when using a Redis Unix socket for caching. This fixes it.

### Description:

Please include a description of this change and which issue it fixes. If no issue exists yet please include context and what problem it solves.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
