### PR TITLE
fixed a PHP8.1 deprecation warning

### DIFF
--- a/src/Backend/Factory.php
+++ b/src/Backend/Factory.php
@@ -59,7 +59,7 @@ class Factory
         if (empty($options['unix_socket'])) {
             $redis->connect($options['host'], $options['port'], $timeout);
         } else {
-            $redis->connect($options['unix_socket'], null, $timeout);
+            $redis->connect($options['unix_socket'], 0, $timeout);
         }
 
         if (!empty($options['password'])) {


### PR DESCRIPTION
Hello, 
this resolves for me the following warning message in PHP 8.1.

`WARNING: /vendor/matomo/cache/src/Backend/Factory.php(62): Deprecated - Redis::connect(): Passing null to parameter #2 ($port) of type int is deprecated - Matomo 4.13.1 - Please report this message in the Matomo forums: https://forum.matomo.org (please do a search first as it might have been reported already) (Module: MultiSites, Action: index, In CLI mode: false)`

[Reported it already last year in Matomo forums.](https://forum.matomo.org/t/redis-cache-with-unix-socket-and-php-8-1/46757?u=whocarez)